### PR TITLE
Use correct GitHub raw content URL

### DIFF
--- a/src/urls.js
+++ b/src/urls.js
@@ -47,7 +47,7 @@ export const parseURLFromBLDRS = (url) => {
       organization: org,
       repository: repo,
       ref: ref,
-      url: new URL(`/${org}/${repo}/blob/${ref}/${path}`, 'https://github.com')
+      url: new URL(`/${org}/${repo}/${ref}/${path}`, 'https://raw.githubusercontent.com')
     }
   }
 


### PR DESCRIPTION
PR to generate the URL for a GitHub raw content download as opposed to HTML view.