### PR TITLE
Fail immediately if cannot create OpenGL context

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -42,6 +42,10 @@ export function initDom() {
 /** Create a WebGL context using the 'gl' package. */
 export function initGl(width, height) {
   const glCtx = gl(width, height, {antialias: true})
+  if (glCtx === null) {
+    throw new Error('Could not create requested WebGL context')
+  }
+
   return glCtx
 }
 


### PR DESCRIPTION
PR to add a check on the return value from the OpenGL context creation.

If the upstream library fails to return an OpenGL context, it will not raise an exception but instead return a `null`.

Blindly passing this `null` along results in further headaches as downstream functions give you meaningless errors that can and will result in wild goose chases.

So now, we perform a quick check and throw an exception if we encounter the `null`.