### PR TITLE
Gracefully handle missing URL

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -32,7 +32,12 @@ app.post('/render', async (req, res) => {
   const camera = initCamera(45, aspect)
   initLights(scene)
 
+  // Get the model URL, if none provided, return a 400 Bad Request
   let ifcURL = req.body.url
+  if (ifcURL === undefined) {
+    res.status(400).send()
+  }
+
   let coordinates = []
   const url = new URL(ifcURL)
   if (url.hostname === 'bldrs.ai') {


### PR DESCRIPTION
PR to return a 400 Bad Request if someone calls without a model URL.

Previously, performing this action would cause the server to crash due to an unhandled exception.