### PR TITLE
Update Docker image to build with Node 18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-slim AS builder
+FROM node:18-slim AS builder
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y libxi-dev libglu1-mesa-dev libglew-dev xvfb && \


### PR DESCRIPTION
PR that updates the Docker image.

This was accidentally left out of the previous PR and as a result, production builds are failing.