### PR TITLE
Require node 16.x in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "serve": "node --enable-source-maps build/server-bundle.js",
     "test": "jest"
   },
+  "engines": {
+    "node": ">=16.0.0 <17.0.0"
+  },
   "dependencies": {
     "@bldrs-ai/conway": "./bldrs-ai-conway-0.1.408.tgz",
     "@sentry/node": "^7.64.0",


### PR DESCRIPTION
Tested like this:

<img width="1359" alt="image" src="https://github.com/bldrs-ai/headless-three/assets/2480879/f4c01d0a-0537-443c-aa73-3af7ffd22714">
